### PR TITLE
fix: 크루 단일 조회 API에 status 추가

### DIFF
--- a/src/main/java/com/gsm/blabla/crew/dto/CrewResponseDto.java
+++ b/src/main/java/com/gsm/blabla/crew/dto/CrewResponseDto.java
@@ -36,11 +36,12 @@ public class CrewResponseDto {
     private Boolean autoApproval;
     private String coverImage;
     private String  createdAt;
+    private String status;
     private List<MemberResponseDto> members;
     private List<String> tags;
 
     public static CrewResponseDto crewResponse(String language, Crew crew,
-        CrewMemberRepository crewMemberRepository) {
+        String status, CrewMemberRepository crewMemberRepository) {
         return CrewResponseDto.builder()
             .name(crew.getName())
             .description(crew.getDescription())
@@ -57,6 +58,7 @@ public class CrewResponseDto {
             .detail(crew.getDetail())
             .autoApproval(crew.getAutoApproval())
             .coverImage(crew.getCoverImage())
+            .status(status)
             .members(crew.getCrewMembers().stream()
                     .map(crewMember -> MemberResponseDto.crewProfileResponse(crew.getId(), crewMember.getMember(),
                 crewMemberRepository))


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
프론트의 요청에 따라 크루 단일 조회 API에 status(내가 이 크루에 가입했는지, 대기중인지 등등...)를 추가했습니다.