### PR TITLE
feat: 프로필 생년월일, 성별, 푸쉬 알림 여부 수정 API 구현 & 더미 데이터 추가

### DIFF
--- a/src/main/java/com/gsm/blabla/dummy/api/DummyController.java
+++ b/src/main/java/com/gsm/blabla/dummy/api/DummyController.java
@@ -5,6 +5,9 @@ import com.gsm.blabla.common.enums.Keyword;
 import com.gsm.blabla.common.enums.Level;
 import com.gsm.blabla.common.enums.PreferMember;
 import com.gsm.blabla.common.enums.Tag;
+import com.gsm.blabla.member.dto.BirthDateDisclosureRequestDto;
+import com.gsm.blabla.member.dto.PushNotificationRequestDto;
+import com.gsm.blabla.member.dto.genderDisclosureRequestDto;
 import com.gsm.blabla.practice.domain.Content;
 import com.gsm.blabla.practice.domain.MemberContent;
 import com.gsm.blabla.practice.dto.ContentListResponseDto;
@@ -33,6 +36,7 @@ import java.util.*;
 import com.gsm.blabla.member.domain.Member;
 import com.gsm.blabla.member.dto.MemberResponseDto;
 import com.gsm.blabla.practice.dto.PracticeFeedbackResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -399,5 +403,20 @@ public class DummyController {
                 .build();
 
         return DataResponseDto.of(PracticeFeedbackResponseDto.of(memberContent));
+    }
+
+    @PatchMapping("/members/push-notification")
+    public DataResponseDto<Map<String, String>> updatePushNotification(@RequestBody PushNotificationRequestDto pushNotificationRequestDto) {
+        return DataResponseDto.of(Map.of("message", "푸쉬 알림 설정이 완료되었습니다."));
+    }
+
+    @PatchMapping("/members/birth-date-disclosure")
+    public DataResponseDto<Map<String, String>> updateBirthDateDisclosure(@RequestBody BirthDateDisclosureRequestDto birthDateDisclosureRequestDto) {
+        return DataResponseDto.of(Map.of("message", "생년월일 공개 여부 설정이 완료되었습니다."));
+    }
+
+    @PatchMapping("/members/gender-disclosure")
+    public DataResponseDto<Map<String, String>> updateGenderDisclosure(@RequestBody genderDisclosureRequestDto genderDisclosureRequestDto) {
+        return DataResponseDto.of(Map.of("message", "성별 공개 여부 설정이 완료되었습니다."));
     }
 }

--- a/src/main/java/com/gsm/blabla/member/api/MemberController.java
+++ b/src/main/java/com/gsm/blabla/member/api/MemberController.java
@@ -2,8 +2,7 @@ package com.gsm.blabla.member.api;
 
 import com.gsm.blabla.global.response.DataResponseDto;
 import com.gsm.blabla.member.application.MemberService;
-import com.gsm.blabla.member.dto.MemberRequestDto;
-import com.gsm.blabla.member.dto.MemberResponseDto;
+import com.gsm.blabla.member.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Map;
@@ -38,5 +37,23 @@ public class MemberController {
     @GetMapping("/{language}/profile")
     public DataResponseDto<MemberResponseDto> getProfile(@PathVariable String language) {
         return DataResponseDto.of(memberService.getProfile(language));
+    }
+
+    @Operation(summary = "푸쉬 알림 설정 API")
+    @PatchMapping("/members/push-notification")
+    public DataResponseDto<Map<String, String>> updatePushNotification(@RequestBody PushNotificationRequestDto pushNotificationRequestDto) {
+        return DataResponseDto.of(memberService.updatePushNotification(pushNotificationRequestDto));
+    }
+
+    @Operation(summary = "생년월일 공개 여부 설정 API")
+    @PatchMapping("/members/birth-date-disclosure")
+    public DataResponseDto<Map<String, String>> updateBirthDateDisclosure(@RequestBody BirthDateDisclosureRequestDto birthDateDisclosureRequestDto) {
+        return DataResponseDto.of(memberService.updateBirthDateDisclosure(birthDateDisclosureRequestDto));
+    }
+
+    @Operation(summary = "성별 공개 여부 설정 API")
+    @PatchMapping("/members/gender-disclosure")
+    public DataResponseDto<Map<String, String>> updateGenderDisclosure(@RequestBody genderDisclosureRequestDto genderDisclosureRequestDto) {
+        return DataResponseDto.of(memberService.updateGenderDisclosure(genderDisclosureRequestDto));
     }
 }

--- a/src/main/java/com/gsm/blabla/member/application/MemberService.java
+++ b/src/main/java/com/gsm/blabla/member/application/MemberService.java
@@ -12,8 +12,7 @@ import java.util.*;
 
 import com.gsm.blabla.member.domain.Member;
 import com.gsm.blabla.member.domain.MemberKeyword;
-import com.gsm.blabla.member.dto.MemberRequestDto;
-import com.gsm.blabla.member.dto.MemberResponseDto;
+import com.gsm.blabla.member.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeanWrapper;
@@ -98,5 +97,38 @@ public class MemberService {
 
 
         return MemberResponseDto.getMemberProfile(member, interests);
+    }
+
+    public Map<String, String> updatePushNotification(PushNotificationRequestDto pushNotificationRequestDto) {
+        Long memberId = SecurityUtil.getMemberId();
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new GeneralException(Code.MEMBER_NOT_FOUND, "존재하지 않는 유저입니다.")
+        );
+
+        member.setPushNotification(pushNotificationRequestDto.getPushNotification());
+
+        return Collections.singletonMap("message", "푸시 알림 설정이 완료되었습니다.");
+    }
+
+    public Map<String, String> updateBirthDateDisclosure(BirthDateDisclosureRequestDto birthDateDisclosureRequestDto) {
+        Long memberId = SecurityUtil.getMemberId();
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new GeneralException(Code.MEMBER_NOT_FOUND, "존재하지 않는 유저입니다.")
+        );
+
+        member.setBirthDateDisclosure(birthDateDisclosureRequestDto.getBirthDateDisclosure());
+
+        return Collections.singletonMap("message", "생년월일 공개 여부 설정이 완료되었습니다.");
+    }
+
+    public Map<String, String> updateGenderDisclosure(genderDisclosureRequestDto genderDisclosure) {
+        Long memberId = SecurityUtil.getMemberId();
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new GeneralException(Code.MEMBER_NOT_FOUND, "존재하지 않는 유저입니다.")
+        );
+
+        member.setGenderDisclosure(genderDisclosure.getGenderDisclosure());
+
+        return Collections.singletonMap("message", "성별 공개 여부 설정이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/gsm/blabla/member/domain/Member.java
+++ b/src/main/java/com/gsm/blabla/member/domain/Member.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -53,19 +54,24 @@ public class Member extends BaseTimeEntity {
 
     private Boolean isWithdrawal = false; // 탈퇴 여부
 
+    private Boolean birthDateDisclosure = true; // 생년월일 공개 여부
+
+    private Boolean genderDisclosure = true; // 성별 공개 여부
+
+
     @Builder
     public Member(SocialLoginType socialLoginType, String nickname, String profileImage,
         LocalDate birthDate, String gender, String countryCode,
-        int korLevel, int engLevel, boolean pushNotification) {
+        Integer korLevel, Integer engLevel, Boolean pushNotification) {
         this.socialLoginType = socialLoginType;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.birthDate = birthDate;
         this.gender = gender;
+        this.pushNotification = pushNotification;
         this.countryCode = countryCode;
         this.korLevel = korLevel;
         this.engLevel = engLevel;
-        this.pushNotification = pushNotification;
     }
 
     public void updateMember(MemberRequestDto memberRequestDto) {

--- a/src/main/java/com/gsm/blabla/member/dto/BirthDateDisclosureRequestDto.java
+++ b/src/main/java/com/gsm/blabla/member/dto/BirthDateDisclosureRequestDto.java
@@ -1,0 +1,8 @@
+package com.gsm.blabla.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BirthDateDisclosureRequestDto {
+    private Boolean birthDateDisclosure;
+}

--- a/src/main/java/com/gsm/blabla/member/dto/PushNotificationRequestDto.java
+++ b/src/main/java/com/gsm/blabla/member/dto/PushNotificationRequestDto.java
@@ -1,0 +1,8 @@
+package com.gsm.blabla.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PushNotificationRequestDto {
+    private Boolean pushNotification;
+}

--- a/src/main/java/com/gsm/blabla/member/dto/genderDisclosureRequestDto.java
+++ b/src/main/java/com/gsm/blabla/member/dto/genderDisclosureRequestDto.java
@@ -1,0 +1,8 @@
+package com.gsm.blabla.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class genderDisclosureRequestDto {
+    private Boolean genderDisclosure;
+}


### PR DESCRIPTION
### 🛰️ Issue Number
#85 

### 🪐 PR 특이사항
1. 프로필 생년월일, 성별, 푸쉬 알림 여부 수정 API 구현했습니다.
2. 프로필 생년월일, 성별, 푸쉬 알림 여부 수정 더미 데이터 추가했습니다.
