### PR TITLE
fix: 프론트 요청에 따른 API response 수정

### DIFF
--- a/src/main/java/com/gsm/blabla/crew/api/CrewController.java
+++ b/src/main/java/com/gsm/blabla/crew/api/CrewController.java
@@ -56,7 +56,7 @@ public class CrewController {
 
     @Operation(summary = "나의 크루 조회 API")
     @GetMapping(value = "/crews/me")
-    public DataResponseDto<List<CrewResponseDto>> getMyCrews() {
+    public DataResponseDto<Map<String, List<CrewResponseDto>>> getMyCrews() {
         return DataResponseDto.of(crewService.getMyCrews());
     }
 

--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -124,13 +124,15 @@ public class CrewService {
     }
 
     // TODO: n + 1 문제 최적화
-    public List<CrewResponseDto> getMyCrews() {
+    public Map<String, List<CrewResponseDto>> getMyCrews() {
         Long memberId = SecurityUtil.getMemberId();
         List<CrewMember> crewMembers = crewMemberRepository.getByMemberIdAndStatus(memberId, CrewMemberStatus.JOINED);
 
-        return crewMembers.stream()
+        List<CrewResponseDto> crews = crewMembers.stream()
             .map(crewMember -> CrewResponseDto.myCrewListResponse(crewMember.getCrew(), crewMemberRepository))
             .toList();
+
+        return Collections.singletonMap("crews", crews);
     }
 
     public Map<String, String> joinCrew(Long crewId, MessageRequestDto messageRequestDto) {

--- a/src/main/java/com/gsm/blabla/crew/application/ScheduleService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/ScheduleService.java
@@ -64,12 +64,16 @@ public class ScheduleService {
 
     @Transactional(readOnly = true)
     public Map<String, List<ScheduleResponseDto>> getAll(Long crewId) {
+        Long memberId = SecurityUtil.getMemberId();
+        Member member = memberRepository.findById(memberId).orElseThrow(
+            () -> new GeneralException(Code.MEMBER_NOT_FOUND, "존재하지 않는 유저입니다."));
         Crew crew = crewRepository.findById(crewId).orElseThrow(
                 () -> new GeneralException(Code.CREW_NOT_FOUND, "존재하지 않는 크루입니다."));
         List<Schedule> schedules = scheduleRepository.findAllByCrewOrderByMeetingTime(crew);
 
         return Collections.singletonMap("schedules", schedules.stream()
-            .map(schedule -> ScheduleResponseDto.of(schedule, crewMemberRepository))
+            .map(schedule -> ScheduleResponseDto.scheduleListResponse(member, schedule,
+                crewMemberRepository, memberScheduleRepository))
             .toList());
     }
 
@@ -81,7 +85,7 @@ public class ScheduleService {
             return new ScheduleResponseDto();
         }
 
-        return ScheduleResponseDto.of(schedule, crewMemberRepository);
+        return ScheduleResponseDto.scheduleResponse(schedule, crewMemberRepository);
     }
 
     public Map<String, String> joinSchedule(Long crewId, ScheduleRequestDto scheduleRequestDto) {

--- a/src/main/java/com/gsm/blabla/crew/application/ScheduleService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/ScheduleService.java
@@ -77,6 +77,10 @@ public class ScheduleService {
     public ScheduleResponseDto getUpcomingSchedule(Long crewId) {
         Schedule schedule = scheduleRepository.findNearestSchedule(crewId);
 
+        if (schedule == null) {
+            return new ScheduleResponseDto();
+        }
+
         return ScheduleResponseDto.of(schedule, crewMemberRepository);
     }
 

--- a/src/main/java/com/gsm/blabla/crew/dao/MemberScheduleRepository.java
+++ b/src/main/java/com/gsm/blabla/crew/dao/MemberScheduleRepository.java
@@ -1,9 +1,15 @@
 package com.gsm.blabla.crew.dao;
 
 import com.gsm.blabla.crew.domain.MemberSchedule;
+import com.gsm.blabla.crew.domain.Schedule;
+import com.gsm.blabla.member.domain.Member;
+import java.util.Optional;
+import java.util.OptionalInt;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberScheduleRepository extends JpaRepository<MemberSchedule, Long> {
 
     MemberSchedule getByScheduleId(Long id);
+
+    Optional<MemberSchedule> findByMemberAndSchedule(Member member, Schedule schedule);
 }

--- a/src/main/java/com/gsm/blabla/crew/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/gsm/blabla/crew/dto/ScheduleResponseDto.java
@@ -2,8 +2,10 @@ package com.gsm.blabla.crew.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gsm.blabla.crew.dao.CrewMemberRepository;
+import com.gsm.blabla.crew.dao.MemberScheduleRepository;
 import com.gsm.blabla.crew.domain.CrewMemberStatus;
 import com.gsm.blabla.crew.domain.Schedule;
+import com.gsm.blabla.member.domain.Member;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -26,19 +28,42 @@ public class ScheduleResponseDto {
     private String meetingTime;
     private Integer dDay;
     private List<String> profiles;
+    private String status; // ENDED, NOT_JOINED, JOINED
 
-    public static ScheduleResponseDto of(Long id, String title, String meetingTime, int dDay, List<String> profiles) {
+    public static ScheduleResponseDto scheduleResponse(Schedule schedule, CrewMemberRepository crewMemberRepository) {
+        List<String> profiles = getProfiles(schedule, crewMemberRepository);
+
         return ScheduleResponseDto.builder()
-            .id(id)
-            .title(title)
-            .meetingTime(meetingTime)
-            .dDay(dDay)
+            .id(schedule.getId())
+            .title(schedule.getTitle())
+            .meetingTime(schedule.getMeetingTime().format(
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            ))
+            .dDay(schedule.getMeetingTime().getDayOfYear() - LocalDateTime.now().getDayOfYear())
             .profiles(profiles)
             .build();
     }
 
-    public static ScheduleResponseDto of(Schedule schedule, CrewMemberRepository crewMemberRepository) {
+    public static ScheduleResponseDto scheduleListResponse(Member member, Schedule schedule,
+        CrewMemberRepository crewMemberRepository, MemberScheduleRepository memberScheduleRepository) {
+        List<String> profiles = getProfiles(schedule, crewMemberRepository);
+        String status = getStatus(member, schedule, memberScheduleRepository);
+
+        return ScheduleResponseDto.builder()
+            .id(schedule.getId())
+            .title(schedule.getTitle())
+            .meetingTime(schedule.getMeetingTime().format(
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            ))
+            .dDay(schedule.getMeetingTime().getDayOfYear() - LocalDateTime.now().getDayOfYear())
+            .profiles(profiles)
+            .status(status)
+            .build();
+    }
+
+    private static List<String> getProfiles(Schedule schedule, CrewMemberRepository crewMemberRepository) {
         List<String> profiles;
+
         if (schedule.getMeetingTime().isBefore(LocalDateTime.now())) {
             profiles = schedule.getMemberSchedules().stream().map(
                 memberSchedule -> memberSchedule.getMember().getProfileImage()
@@ -52,14 +77,19 @@ public class ScheduleResponseDto {
             ).filter(Objects::nonNull).toList();
         }
 
-        return ScheduleResponseDto.builder()
-            .id(schedule.getId())
-            .title(schedule.getTitle())
-            .meetingTime(schedule.getMeetingTime().format(
-                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-            ))
-            .dDay(schedule.getMeetingTime().getDayOfYear() - LocalDateTime.now().getDayOfYear())
-            .profiles(profiles)
-            .build();
+        return profiles;
+    }
+
+    private static String getStatus(Member member, Schedule schedule, MemberScheduleRepository memberScheduleRepository) {
+        String status = "";
+
+        if (schedule.getMeetingTime().isBefore(LocalDateTime.now())) {
+            status = "ENDED";
+        } else {
+            boolean isJoined = memberScheduleRepository.findByMemberAndSchedule(member, schedule).isPresent();
+            status = isJoined ? "JOINED" : "NOT_JOINED";
+        }
+
+        return status;
     }
 }

--- a/src/main/java/com/gsm/blabla/crew/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/gsm/blabla/crew/dto/ScheduleResponseDto.java
@@ -1,5 +1,6 @@
 package com.gsm.blabla.crew.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gsm.blabla.crew.dao.CrewMemberRepository;
 import com.gsm.blabla.crew.domain.CrewMemberStatus;
 import com.gsm.blabla.crew.domain.Schedule;
@@ -8,11 +9,17 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ScheduleResponseDto {
     private Long id;
     private String title;


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
- 나의 크루 조회 API에서 크루가 없을 때 빈 crews 리스트를 반환하도록 수정했습니다.
- 다가오는 크루 일정 API에서 다가오는 일정이 없을 때 빈 data json을 반환하도록 수정했습니다.
- 크루 일정 전체 조회 API에서 참여 및 종료 여부를 추가하였습니다.
