### PR TITLE
feat: 일정 참여 취소 API 구현

### DIFF
--- a/src/main/java/com/gsm/blabla/crew/api/ScheduleController.java
+++ b/src/main/java/com/gsm/blabla/crew/api/ScheduleController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/crews/{crewId}/schedules")
 @RequiredArgsConstructor
 public class ScheduleController {
+
     private final ScheduleService scheduleService;
 
     @Operation(summary = "크루 일정 생성 API")
@@ -54,4 +56,12 @@ public class ScheduleController {
         return DataResponseDto.of(scheduleService.joinSchedule(crewId, scheduleRequestDto));
     }
 
+    @Operation(summary = "크루 일정 참여 취소 API")
+    @DeleteMapping(value = "")
+    public DataResponseDto<Map<String, String>> cancelSchedule(
+        @PathVariable Long crewId,
+        @RequestBody ScheduleRequestDto scheduleRequestDto
+        ) {
+        return DataResponseDto.of(scheduleService.cancelSchedule(crewId, scheduleRequestDto));
+    }
 }

--- a/src/main/java/com/gsm/blabla/crew/domain/MemberSchedule.java
+++ b/src/main/java/com/gsm/blabla/crew/domain/MemberSchedule.java
@@ -20,6 +20,8 @@ public class MemberSchedule {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String status;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -30,7 +32,16 @@ public class MemberSchedule {
 
     @Builder
     public MemberSchedule(Member member, Schedule schedule) {
+        this.status = "JOINED";
         this.member = member;
         this.schedule = schedule;
+    }
+
+    public void joinAgain() {
+        this.status = "JOINED";
+    }
+
+    public void cancel() {
+        this.status = "CANCELED";
     }
 }

--- a/src/main/java/com/gsm/blabla/crew/domain/Schedule.java
+++ b/src/main/java/com/gsm/blabla/crew/domain/Schedule.java
@@ -25,6 +25,7 @@ public class Schedule extends BaseTimeEntity {
 
     private LocalDateTime meetingTime;
     private String title;
+    private String status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "crew_id")

--- a/src/main/java/com/gsm/blabla/crew/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/gsm/blabla/crew/dto/ScheduleResponseDto.java
@@ -8,14 +8,12 @@ import com.gsm.blabla.crew.domain.Schedule;
 import com.gsm.blabla.member.domain.Member;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
@@ -65,11 +63,15 @@ public class ScheduleResponseDto {
         List<String> profiles;
 
         if (schedule.getMeetingTime().isBefore(LocalDateTime.now())) {
-            profiles = schedule.getMemberSchedules().stream().map(
+            profiles = schedule.getMemberSchedules().stream()
+                .filter(memberSchedule -> memberSchedule.getStatus().equals("JOINED"))
+                .map(
                 memberSchedule -> memberSchedule.getMember().getProfileImage()
             ).toList();
         } else {
-            profiles = schedule.getMemberSchedules().stream().map(
+            profiles = schedule.getMemberSchedules().stream()
+                .filter(memberSchedule -> memberSchedule.getStatus().equals("JOINED"))
+                .map(
                 memberSchedule -> {
                     boolean isJoined = crewMemberRepository.getByCrewAndMemberAndStatus(schedule.getCrew(), memberSchedule.getMember(), CrewMemberStatus.JOINED).isPresent();
                     return isJoined ? memberSchedule.getMember().getProfileImage() : null;


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->
#114 

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
- 일정 참여 취소 API를 구현하며 MemberSchedule 엔티티에 status를 추가했습니다. (JOINED, CANCELED)
- 일정을 조회할 때 status가 JOINED인 크루원의 프로필만 반환하도록 수정했습니다.
