### PR TITLE
fix: 회원 탈퇴 시 appleAccount, googleAccount, jwt 엔티티 삭제 로직 추가

### DIFF
--- a/src/main/java/com/gsm/blabla/auth/application/AuthService.java
+++ b/src/main/java/com/gsm/blabla/auth/application/AuthService.java
@@ -315,4 +315,34 @@ public class AuthService {
         PrivateKeyInfo object = (PrivateKeyInfo) pemParser.readObject();
         return converter.getPrivateKey(object);
     }
+
+    public void revokeAppleAccount(Long memberId) {
+        try {
+            String appleRefreshToken = appleAccountRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new GeneralException(Code.MEMBER_NOT_FOUND, "존재하지 않는 유저입니다.")).getRefreshToken();
+
+            HttpHeaders headers = new HttpHeaders();
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+            params.add("client_id", appleClientId);
+            params.add("client_secret", getAppleClientSecret());
+            params.add("token", appleRefreshToken);
+            params.add("token_type_hint", "refresh_token");
+
+            new RestTemplate().exchange(
+                "https://appleid.apple.com/auth/revoke",
+                HttpMethod.POST,
+                new HttpEntity<>(params, headers),
+                String.class
+            );
+
+            appleAccountRepository.deleteByMemberId(memberId);
+        } catch (Exception e) {
+            throw new GeneralException(Code.APPLE_SERVER_ERROR, e);
+        }
+    }
+
+    public void unlinkGoogleAccount(Long memberId) {
+        googleAccountRepository.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/gsm/blabla/jwt/dao/AppleAccountRepository.java
+++ b/src/main/java/com/gsm/blabla/jwt/dao/AppleAccountRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AppleAccountRepository extends JpaRepository<AppleAccount, String> {
 
     Optional<AppleAccount> findByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/gsm/blabla/jwt/dao/GoogleAccountRepository.java
+++ b/src/main/java/com/gsm/blabla/jwt/dao/GoogleAccountRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GoogleAccountRepository extends JpaRepository<GoogleAccount, String> {
     Optional<GoogleAccount> findById(String id);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/gsm/blabla/jwt/dao/JwtRepository.java
+++ b/src/main/java/com/gsm/blabla/jwt/dao/JwtRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface JwtRepository extends JpaRepository<Jwt, Long> {
     Optional<Jwt> findOneByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->
#136 

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
- 회원 탈퇴 시 appleAccount, googleAccount, jwt 엔티티도 함께 삭제되도록 로직을 추가하였습니다.