### PR TITLE
fix: 일정 전체 조회 API에서 참여 인원이 없을 경우 status를 NOT_JOINED로 수정

### DIFF
--- a/src/main/java/com/gsm/blabla/crew/domain/MemberSchedule.java
+++ b/src/main/java/com/gsm/blabla/crew/domain/MemberSchedule.java
@@ -42,6 +42,6 @@ public class MemberSchedule {
     }
 
     public void cancel() {
-        this.status = "CANCELED";
+        this.status = "NOT_JOINED";
     }
 }

--- a/src/main/java/com/gsm/blabla/crew/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/gsm/blabla/crew/dto/ScheduleResponseDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gsm.blabla.crew.dao.CrewMemberRepository;
 import com.gsm.blabla.crew.dao.MemberScheduleRepository;
 import com.gsm.blabla.crew.domain.CrewMemberStatus;
+import com.gsm.blabla.crew.domain.MemberSchedule;
 import com.gsm.blabla.crew.domain.Schedule;
 import com.gsm.blabla.member.domain.Member;
 import com.gsm.blabla.member.dto.MemberResponseDto;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -113,8 +115,12 @@ public class ScheduleResponseDto {
         if (schedule.getMeetingTime().isBefore(LocalDateTime.now())) {
             status = "ENDED";
         } else {
-            boolean isJoined = memberScheduleRepository.findByMemberAndSchedule(member, schedule).isPresent();
-            status = isJoined ? "JOINED" : "NOT_JOINED";
+            Optional<MemberSchedule> optionalMemberSchedule = memberScheduleRepository.findByMemberAndSchedule(member, schedule);
+
+            status = optionalMemberSchedule
+                .filter(memberSchedule -> !memberSchedule.getStatus().equals("JOINED"))
+                .map(memberSchedule -> "NOT_JOINED")
+                .orElse("JOINED");
         }
 
         return status;


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
- 크루 일정에 참여를 한 뒤, 일정 취소를 할 경우 일정 전체 조회 API에서 status가 JOINED로 되어있는 문제를 해결했습니다.
