### PR TITLE
fix: 크루 리포트 목록 조회 API에서 리포트 분석 결과가 없을 경우에도 null이 포함된 리스트 반환

### DIFF
--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -587,13 +587,16 @@ public class CrewService {
                 Map<String, String> info = crewReportAnalysis.map(
                     reportAnalysis -> getReportInfo(crewReport, reportAnalysis)).orElse(null);
 
+                if (info == null) {
+                    return null;
+                }
                 return CrewReportResponseDto.crewReportListResponse(crewReport.getId(), generated,
                     members, info);
             })
             .sorted(Comparator.comparing((CrewReportResponseDto report) -> {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
                 return LocalDateTime.parse(report.getInfo().get("createdAt"), formatter);
-            }).reversed())
+            }, Comparator.nullsFirst(Comparator.reverseOrder())))
             .toList()
         );
 

--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -581,11 +581,12 @@ public class CrewService {
                     .map(MemberResponseDto::crewReportResponse)
                     .toList();
 
-                CrewReportAnalysis crewReportAnalysis = crewReportAnalysisRepository.findByCrewReport(
-                    crewReport).orElseThrow(
-                    () -> new GeneralException(Code.REPORT_ANALYSIS_IS_NULL, "존재하지 않는 리포트 분석입니다.")
-                );
-                Map<String, String> info = getReportInfo(crewReport, crewReportAnalysis);
+                Optional<CrewReportAnalysis> crewReportAnalysis = crewReportAnalysisRepository.findByCrewReport(
+                    crewReport);
+
+                Map<String, String> info = crewReportAnalysis.map(
+                    reportAnalysis -> getReportInfo(crewReport, reportAnalysis)).orElse(null);
+
                 return CrewReportResponseDto.crewReportListResponse(crewReport.getId(), generated,
                     members, info);
             })


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
기존 로직: 크루 리포트 목록 조회 API에서 리포트 분석 결과가 없을 경우 exception을 던진다.
수정 로직: 크루 리포트 목록 조회 API에서 리포트 분석 결과가 없을 경우 CrewReportResponseDto를 null로 던지며, 리스트 맨 앞에 배치한다.