### PR TITLE
fix: 히스토리 조회 API NullPointerException 오류 해결

### DIFF
--- a/src/main/java/com/gsm/blabla/report/application/ReportService.java
+++ b/src/main/java/com/gsm/blabla/report/application/ReportService.java
@@ -76,6 +76,7 @@ public class ReportService {
         List<HistoryReportResponseDto> personalHistory = new ArrayList<>();
         for (MemberContent memberContent : memberContents) {
             String subTitle = memberContent.getContent().getGenre() + " - " + memberContent.getContent().getContentName();
+            String datetime = memberContent.getJoinedAt().format(formatter);
             personalHistory.add(
                 HistoryReportResponseDto.builder()
                     .id(memberContent.getContent().getId())
@@ -86,6 +87,7 @@ public class ReportService {
                             "subTitle", subTitle
                         )
                     )
+                    .dateTime(datetime)
                     .build()
 
             );


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
```
java.lang.NullPointerException: element cannot be mapped to a null key
```
조회 로직에서 personalHistory 리스트의 원소들에 datetime이 없어 groupingBy를 할 때 위와 같은 에러가 발생하였으며, datetime을 추가하여 문제를 해결했습니다.
