### PR TITLE
fix: 크루 리포트 목록 조회 API info가 null일 경우 createdAt, durationTime을 빈 문자열로 반환

### DIFF
--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -585,11 +585,12 @@ public class CrewService {
                     crewReport);
 
                 Map<String, String> info = crewReportAnalysis.map(
-                    reportAnalysis -> getReportInfo(crewReport, reportAnalysis)).orElse(null);
+                    reportAnalysis -> getReportInfo(crewReport, reportAnalysis)).orElse(
+                        Map.of("createdAt", "",
+                            "durationTime", ""
+                        )
+                );
 
-                if (info == null) {
-                    return null;
-                }
                 return CrewReportResponseDto.crewReportListResponse(crewReport.getId(), generated,
                     members, info);
             })


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
크루 리포트 목록 조회 API에서 info가 null일 경우 반환하는 response 형태를 변경하였습니다.
- 기존: CrewReportResponseDto를 null로 반환
- 수정: CrewReportResponseDto 속 info의 createdAt과 durationTime을 빈 문자열로 반환