### PR TITLE
fix: crewReport의 endAt을 가져올 때 null exception 문제 해결

### DIFF
--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -617,8 +617,11 @@ public class CrewService {
 
         info.put("createdAt", crewReportAnalysis.getCreatedAt().format(formatter));
 
-        Duration duration = Duration.between(crewReport.getStartedAt(), crewReport.getEndAt());
-        String durationTime = String.format("%02d:%02d:%02d", duration.toHours(), duration.toMinutesPart(), duration.toSecondsPart());
+        String durationTime = "0000-00-00 00:00";
+        if (Objects.equals(crewReport.getEndAt(), LocalDateTime.of(2023, 1, 1, 0, 0, 0))) {
+            Duration duration = Duration.between(crewReport.getStartedAt(), crewReport.getEndAt());
+            durationTime = String.format("%02d:%02d:%02d", duration.toHours(), duration.toMinutesPart(), duration.toSecondsPart());
+        }
         info.put("durationTime", durationTime);
 
         return info;

--- a/src/main/java/com/gsm/blabla/crew/domain/CrewReport.java
+++ b/src/main/java/com/gsm/blabla/crew/domain/CrewReport.java
@@ -21,7 +21,7 @@ public class CrewReport {
     @JoinColumn(name = "crew_id")
     private Crew crew;
     private LocalDateTime startedAt;
-    private LocalDateTime endAt;
+    private LocalDateTime endAt = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
 
     @OneToMany(mappedBy = "crewReport")
     private List<VoiceFile> voiceFiles;

--- a/src/main/java/com/gsm/blabla/report/application/ReportService.java
+++ b/src/main/java/com/gsm/blabla/report/application/ReportService.java
@@ -11,12 +11,14 @@ import com.gsm.blabla.practice.domain.MemberContent;
 import com.gsm.blabla.report.dto.HistoryReportResponseDto;
 import com.gsm.blabla.report.dto.HistoryResponseDto;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,8 +52,11 @@ public class ReportService {
             Optional<CrewReportAnalysis> crewReportAnalysis = crewReportAnalysisRepository.findByCrewReport(crewReport);
             crewReportAnalysis.ifPresent(
                 analysis -> {
-                    Duration duration = Duration.between(crewReport.getStartedAt(), crewReport.getEndAt());
-                    String durationTime = String.format("%02d:%02d:%02d", duration.toHours(), duration.toMinutesPart(), duration.toSecondsPart());
+                    String durationTime = "0000-00-00 00:00";
+                    if (Objects.equals(crewReport.getEndAt(), LocalDateTime.of(2023, 1, 1, 0, 0, 0))) {
+                        Duration duration = Duration.between(crewReport.getStartedAt(), crewReport.getEndAt());
+                        durationTime = String.format("%02d:%02d:%02d", duration.toHours(), duration.toMinutesPart(), duration.toSecondsPart());
+                    }
 
                     String datetime = analysis.getCreatedAt().format(formatter);
                     crewHistory.add(


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
- 기존: 엔티티 생성시 endAt이 null로 들어감
- 수정: 2023년 1월 1일 0시 0분 0초로 들어감 (이미 지난 날짜이니 endAt이 해당 날짜가 될 수 없음)
  - endAt이 2023년 1월 1일 0시 0분 0초일 경우 durationTime을 0000-00-00 00:00로 반환하도록 하였습니다.