### PR TITLE
fix: 디스코드 웹훅 도입으로 인한 테스트 코드 에러 수정 및 테스트 코드 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,4 +131,19 @@ jacocoTestReport {
         html.enabled true
         html.destination file("${buildDir}/jacoco/index.html")
     }
+
+    def Qdomains = []
+    for(qPattern in "**/QA" .. "**/QZ"){
+        Qdomains.add(qPattern+"*")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: [
+                            '**/dummy/**/*.*'
+                    ] + Qdomains)
+                })
+        )
+    }
 }

--- a/src/main/java/com/gsm/blabla/crew/domain/CrewReport.java
+++ b/src/main/java/com/gsm/blabla/crew/domain/CrewReport.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Entity
@@ -30,9 +29,10 @@ public class CrewReport {
     private List<CrewReportKeyword> keywords;
 
     @Builder
-    public CrewReport(Crew crew, LocalDateTime startedAt) {
+    public CrewReport(Crew crew, LocalDateTime startedAt, LocalDateTime endAt) {
         this.crew = crew;
         this.startedAt = startedAt;
+        this.endAt = endAt;
     }
 
     public void updateEndAt(LocalDateTime endAt) {

--- a/src/main/java/com/gsm/blabla/global/exception/ExceptionHandler.java
+++ b/src/main/java/com/gsm/blabla/global/exception/ExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -25,8 +26,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Slf4j
 @RequiredArgsConstructor
 public class ExceptionHandler extends ResponseEntityExceptionHandler {
-
-    private final WebhookService webhookService;
 
     @org.springframework.web.bind.annotation.ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
@@ -66,7 +65,7 @@ public class ExceptionHandler extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<Object> handleExceptionInternal(Exception e, Code errorCode,
         HttpHeaders headers, HttpStatus status, WebRequest request) {
-        webhookService.sendErrorLog(e.getMessage(), e.toString());
+        WebhookService.sendErrorLog(e.getMessage(), e.toString());
         log.error(e.getMessage(), e);
 
         return super.handleExceptionInternal(

--- a/src/main/java/com/gsm/blabla/global/webhook/service/WebhookService.java
+++ b/src/main/java/com/gsm/blabla/global/webhook/service/WebhookService.java
@@ -12,15 +12,15 @@ import org.springframework.web.client.RestTemplate;
 public class WebhookService {
 
     @Value("${discord.webhook.url.dev}")
-    private String devWebhookUrl;
+    private static String devWebhookUrl;
 
     @Value("${discord.webhook.url.prod}")
-    private String prodWebhookUrl;
+    private static String prodWebhookUrl;
 
     @Value("${spring.profiles.active}")
-    private String activeProfile;
+    private static String activeProfile;
 
-    public void sendErrorLog(String title, String description) {
+    public static void sendErrorLog(String title, String description) {
         String webhookUrl = "";
         if (activeProfile.equals("local")) {
             return;

--- a/src/test/java/com/gsm/blabla/BlablaApplicationTests.java
+++ b/src/test/java/com/gsm/blabla/BlablaApplicationTests.java
@@ -3,7 +3,7 @@ package com.gsm.blabla;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active=local")
 class BlablaApplicationTests {
 
     @Test

--- a/src/test/java/com/gsm/blabla/crew/application/ScheduleServiceTest.java
+++ b/src/test/java/com/gsm/blabla/crew/application/ScheduleServiceTest.java
@@ -231,7 +231,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         assertThat(memberScheduleRepository.findByMemberAndSchedule(member1, scheduleRepository.findById(scheduleId)
             .orElseThrow(() -> new GeneralException(Code.SCHEDULE_NOT_FOUND, "존재하지 않는 일정입니다."))
         ).get().getStatus()
-        ).isEqualTo("CANCELED");
+        ).isEqualTo("NOT_JOINED");
     }
 
     private ScheduleRequestDto createScheduleRequestDto(String meetingTime) {

--- a/src/test/java/com/gsm/blabla/global/ControllerTestSupport.java
+++ b/src/test/java/com/gsm/blabla/global/ControllerTestSupport.java
@@ -12,11 +12,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = {
+@WebMvcTest(
+    controllers = {
     CrewController.class,
     AgoraController.class,
     ReportController.class
-})
+    },
+    properties = "spring.profiles.active=local"
+)
 public abstract class ControllerTestSupport {
 
     @Autowired

--- a/src/test/java/com/gsm/blabla/global/IntegrationTestSupport.java
+++ b/src/test/java/com/gsm/blabla/global/IntegrationTestSupport.java
@@ -157,6 +157,7 @@ public abstract class IntegrationTestSupport {
             CrewReport.builder()
                 .crew(crew)
                 .startedAt(startedAt)
+                .endAt(startedAt.plusMinutes(26).plusSeconds(30))
                 .build()
         );
     }

--- a/src/test/java/com/gsm/blabla/global/IntegrationTestSupport.java
+++ b/src/test/java/com/gsm/blabla/global/IntegrationTestSupport.java
@@ -32,7 +32,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = "spring.profiles.active=local"
+)
 public abstract class IntegrationTestSupport {
 
     @LocalServerPort
@@ -182,7 +185,6 @@ public abstract class IntegrationTestSupport {
                 .koreanTime(Duration.ofMinutes(20))
                 .englishTime(Duration.ofMinutes(6))
                 .cloudUrl("www.test.com")
-                .endAt(startedAt.plusMinutes(26).plusSeconds(30))
                 .build()
         );
 


### PR DESCRIPTION
### 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요 -->
#12 

### 🪐 PR 특이사항
<!-- 주요 변경사항이나 코드 리뷰 시 팀원이 참고해주면 좋을 부분을 적어주세요. -->
- 디스코드 웹훅 도입 후 발생한 테스트 코드 에러를 수정했습니다.
- 크루 리포트 목록 조회와 크루 일정 참여 취소에 대한 Service 테스트 코드가 성공하도록 수정했습니다.
- jacoco 테스트 커버리지 분석 대상에서 dummy api와 QClass를 제외했습니다.
