### PR TITLE
fix: 연습 기록 저장 API 수정

### DIFF
--- a/src/main/java/com/gsm/blabla/content/api/ContentController.java
+++ b/src/main/java/com/gsm/blabla/content/api/ContentController.java
@@ -62,11 +62,11 @@ public class ContentController {
     }
 
     @Operation(summary = "연습 기록 음성 파일 저장 API")
-    @PostMapping("/contents/{contentId}/practice")
+    @PostMapping("/contents/detail/{contentDetailId}/practice")
     public DataResponseDto<Map<String, String>> createPracticeHistory(
-            @PathVariable Long contentId,
+            @PathVariable Long contentDetailId,
             @RequestParam("files") List<MultipartFile> files) {
-        return DataResponseDto.of(practiceService.savePracticeHistory(contentId, files));
+        return DataResponseDto.of(practiceService.savePracticeHistory(contentDetailId, files));
     }
 }
 

--- a/src/main/java/com/gsm/blabla/content/application/ContentService.java
+++ b/src/main/java/com/gsm/blabla/content/application/ContentService.java
@@ -29,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -159,8 +160,10 @@ public class ContentService {
                 .orElseThrow(() -> new GeneralException(Code.MEMBER_CONTENT_NOT_FOUND, "존재하지 않는 유저 컨텐츠입니다.")
         );
 
-        for (MultipartFile file : files) {
-            String fileName = String.format("members/%s/contents/%s/%s.wav", String.valueOf(memberId), String.valueOf(contentDetailId), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm")));
+        IntStream.range(0, files.size()).forEach(index -> {
+            MultipartFile file = files.get(index);
+
+            String fileName = String.format("members/%s/contents/%s/%s.wav", String.valueOf(memberId), String.valueOf(contentDetailId), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm'I'")).concat(String.valueOf(index + 1)));
             String fileUrl = s3UploaderService.uploadFile(fileName, file);
 
             practiceHistoryRepository.save(PracticeHistory.builder()
@@ -168,7 +171,7 @@ public class ContentService {
                     .practiceUrl(fileUrl)
                     .build()
             );
-        }
+        });
 
         return Collections.singletonMap("message", "연습 기록 음성 파일이 저장 완료되었습니다.");
     }


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
#190 

## 🪐 작업 내용
- 연습 기록 저장 API를 수정했습니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->
- 빠른 업데이트를 위해 기존 코드 수정만 진행해서 기능 동작 여부를 위주로 리뷰해주시면 감사하겠습니다! 코드는 추후 리팩토링을 통해 개선하도록 하겠습니다 😊

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
- 빠른 업데이트를 위해 테스트 코드는 추후 작성할 예정입니다. 대신 Postman과 S3 저장 결과 첨부하겠습니다!
<img width="495" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/62024470/a2facc2f-ef7b-4fb7-9e28-f788a6661da2">
<img width="1202" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/62024470/e44678c4-d746-4909-a95e-2a538a0d1791">


## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
