### PR TITLE
fix: 회원가입 API에서 pushNotification 제거

### DIFF
--- a/src/main/java/com/gsm/blabla/member/domain/Member.java
+++ b/src/main/java/com/gsm/blabla/member/domain/Member.java
@@ -37,19 +37,18 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role = Role.ROLE_USER; // 역할
 
-    private Boolean pushNotification; // 푸시 알림 허용 여부
+    private Boolean pushNotification = false; // 푸시 알림 허용 여부
 
     private Boolean isWithdrawal = false; // 탈퇴 여부
 
 
     @Builder
     public Member(SocialLoginType socialLoginType, String nickname, String profileImage,
-        String learningLanguage, Boolean pushNotification) {
+        String learningLanguage) {
         this.socialLoginType = socialLoginType;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.learningLanguage = learningLanguage;
-        this.pushNotification = pushNotification;
     }
 
     public void updateMember(MemberProfileRequestDto memberProfileRequestDto) {

--- a/src/main/java/com/gsm/blabla/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/gsm/blabla/member/dto/MemberRequestDto.java
@@ -18,7 +18,6 @@ public class MemberRequestDto {
 
     private String socialLoginType;
     private String learningLanguage;
-    private Boolean pushNotification;
     private List<Long> ids;
 
     public Member toEntity(String nickname, String profileImage) {
@@ -27,7 +26,6 @@ public class MemberRequestDto {
             .nickname(nickname)
             .profileImage(profileImage)
             .learningLanguage(learningLanguage)
-            .pushNotification(pushNotification)
             .build();
     }
 }

--- a/src/test/java/com/gsm/blabla/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/gsm/blabla/auth/api/AuthControllerTest.java
@@ -42,7 +42,6 @@ class AuthControllerTest extends ControllerTestSupport {
                     MemberRequestDto.builder()
                         .socialLoginType("TEST")
                         .learningLanguage("ko")
-                        .pushNotification(false)
                         .build()
                 ))
         )

--- a/src/test/java/com/gsm/blabla/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/gsm/blabla/auth/application/AuthServiceTest.java
@@ -133,7 +133,6 @@ class AuthServiceTest extends IntegrationTestSupport {
         return MemberRequestDto.builder()
             .socialLoginType(socialLoginType)
             .learningLanguage("ko")
-            .pushNotification(false)
             .build();
     }
 }

--- a/src/test/java/com/gsm/blabla/crew/api/CrewControllerTest.java
+++ b/src/test/java/com/gsm/blabla/crew/api/CrewControllerTest.java
@@ -30,7 +30,6 @@ class CrewControllerTest extends ControllerTestSupport {
     void setUp() {
         memberRequestDto = MemberRequestDto.builder()
             .socialLoginType("TEST")
-            .pushNotification(false)
             .build();
     }
 

--- a/src/test/java/com/gsm/blabla/global/IntegrationTestSupport.java
+++ b/src/test/java/com/gsm/blabla/global/IntegrationTestSupport.java
@@ -93,7 +93,6 @@ public abstract class IntegrationTestSupport {
             .nickname("테스트")
             .profileImage(profileImage)
             .learningLanguage("ko")
-            .pushNotification(false)
             .build()
         );
     }


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
#190 

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
- 프론트의 요청에 따라, 회원가입 시 pushNotification이 항상 false이기 때문에 request에서 pushNotification을 제거하고, DB에 데이터가 삽입될 시 false로 삽입되도록 수정하였습니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
<img width="509" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/b5ffea6f-ab05-4f45-b7ff-4644a35216c2">


## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
