### PR TITLE
fix: 애플 로그인 API 에러 수정

### DIFF
--- a/src/main/java/com/gsm/blabla/auth/application/AppleService.java
+++ b/src/main/java/com/gsm/blabla/auth/application/AppleService.java
@@ -38,7 +38,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -74,7 +73,7 @@ public class AppleService {
             String headerOfIdentityToken = identityToken.substring(0, identityToken.indexOf("."));
 
             Map<String, String> header = new ObjectMapper().readValue(
-                new String(Base64Utils.decodeFromUrlSafeString(headerOfIdentityToken), StandardCharsets.UTF_8),
+                new String(Base64.getUrlDecoder().decode(headerOfIdentityToken), StandardCharsets.UTF_8),
                 Map.class
             );
             ApplePublicKeyDto.Key key = applePublicKey.getMatchedKeyBy(header.get("kid"), header.get("alg"))

--- a/src/main/java/com/gsm/blabla/auth/dto/AppleAccountDto.java
+++ b/src/main/java/com/gsm/blabla/auth/dto/AppleAccountDto.java
@@ -3,11 +3,15 @@ package com.gsm.blabla.auth.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class AppleAccountDto {


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
X

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
- Base64Utils가 deprecated되어 Base64로 변경하였습니다.
- AppleAccountDto에 생성자를 추가하여 애플 로그인이 안되는 문제를 해결했습니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
<img width="513" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/974cf923-5a52-4ea8-838c-bbf2a45a23f1">

## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
