### PR TITLE
feat: 보이스룸 접속 유저 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/gsm/blabla/agora/api/AgoraController.java
+++ b/src/main/java/com/gsm/blabla/agora/api/AgoraController.java
@@ -4,9 +4,13 @@ import com.gsm.blabla.agora.application.AgoraService;
 import com.gsm.blabla.agora.dto.RtcTokenDto;
 import com.gsm.blabla.agora.dto.VoiceRoomRequestDto;
 import com.gsm.blabla.global.response.DataResponseDto;
+import com.gsm.blabla.member.dto.MemberResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,4 +30,9 @@ public class AgoraController {
         return DataResponseDto.of(agoraService.create(voiceRoomRequestDto));
     }
 
+    @Operation(summary = "보이스룸 접속 유저 목록 조회 API")
+    @GetMapping(value = "")
+    public DataResponseDto<Map<String, List<MemberResponseDto>>> getMembers() {
+        return DataResponseDto.of(agoraService.getMembers());
+    }
 }

--- a/src/main/java/com/gsm/blabla/agora/api/AgoraController.java
+++ b/src/main/java/com/gsm/blabla/agora/api/AgoraController.java
@@ -9,16 +9,18 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Agora 관련 API")
 @RestController
+@RequestMapping("/crews/voice-room")
 @RequiredArgsConstructor
 public class AgoraController {
     private final AgoraService agoraService;
 
     @Operation(summary = "보이스룸 입장 API")
-    @PostMapping(value = "/crews/voice-room")
+    @PostMapping(value = "")
     public DataResponseDto<RtcTokenDto> create(
         @RequestBody VoiceRoomRequestDto voiceRoomRequestDto) {
         return DataResponseDto.of(agoraService.create(voiceRoomRequestDto));

--- a/src/main/java/com/gsm/blabla/agora/application/AgoraService.java
+++ b/src/main/java/com/gsm/blabla/agora/application/AgoraService.java
@@ -12,7 +12,6 @@ import com.gsm.blabla.global.exception.GeneralException;
 import com.gsm.blabla.global.response.Code;
 import com.gsm.blabla.global.util.SecurityUtil;
 import com.gsm.blabla.member.dao.MemberRepository;
-import com.gsm.blabla.member.domain.Member;
 import com.gsm.blabla.member.dto.MemberResponseDto;
 import java.time.LocalDateTime;
 import java.util.Collections;

--- a/src/main/java/com/gsm/blabla/agora/application/AgoraService.java
+++ b/src/main/java/com/gsm/blabla/agora/application/AgoraService.java
@@ -28,6 +28,7 @@ public class AgoraService {
 
     private final CrewReportRepository crewReportRepository;
     private final MemberRepository memberRepository;
+    private final VoiceRoomRepository voiceRoomRepository;
 
     static final int TOKEN_EXPIRATION_TIME = 1000 * 60 * 30;
     static final int PRIVILEGE_EXPIRATION_TIME = 1000 * 60 * 30;
@@ -48,6 +49,20 @@ public class AgoraService {
                     ))
                     .build()
              );
+        }
+
+        boolean inVoiceRoom = voiceRoomRepository.existsByMemberId(memberId);
+        if (inVoiceRoom) {
+            throw new GeneralException(Code.ALREADY_IN_VOICE_ROOM, "이미 보이스 채팅방에 입장하셨습니다.");
+        } else {
+            voiceRoomRepository.save(
+                VoiceRoom.builder()
+                    .member(memberRepository.findById(memberId).orElseThrow(
+                        () -> new GeneralException(Code.MEMBER_NOT_FOUND, "존재하지 않는 유저입니다.")
+                    ))
+                    .inVoiceRoom(true)
+                    .build()
+            );
         }
 
         return RtcTokenDto.builder()

--- a/src/main/java/com/gsm/blabla/agora/application/AgoraService.java
+++ b/src/main/java/com/gsm/blabla/agora/application/AgoraService.java
@@ -2,6 +2,8 @@ package com.gsm.blabla.agora.application;
 
 import com.gsm.blabla.agora.RtcTokenBuilder2;
 import com.gsm.blabla.agora.RtcTokenBuilder2.Role;
+import com.gsm.blabla.agora.dao.VoiceRoomRepository;
+import com.gsm.blabla.agora.domain.VoiceRoom;
 import com.gsm.blabla.agora.dto.RtcTokenDto;
 import com.gsm.blabla.agora.dto.VoiceRoomRequestDto;
 import com.gsm.blabla.crew.dao.CrewReportRepository;
@@ -10,8 +12,13 @@ import com.gsm.blabla.global.exception.GeneralException;
 import com.gsm.blabla.global.response.Code;
 import com.gsm.blabla.global.util.SecurityUtil;
 import com.gsm.blabla.member.dao.MemberRepository;
+import com.gsm.blabla.member.domain.Member;
+import com.gsm.blabla.member.dto.MemberResponseDto;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -71,5 +78,14 @@ public class AgoraService {
             .expiresIn(new Date(now + TOKEN_EXPIRATION_TIME).getTime())
             .reportId(crewReportRepository.findCurrentId())
             .build();
+    }
+
+    public Map<String, List<MemberResponseDto>> getMembers() {
+        List<MemberResponseDto> membersInVoiceRoom = voiceRoomRepository.findAllByInVoiceRoom(true).stream()
+            .map(VoiceRoom::getMember)
+            .map(MemberResponseDto::voiceRoomResponse)
+            .toList();
+
+        return Collections.singletonMap("members", membersInVoiceRoom);
     }
 }

--- a/src/main/java/com/gsm/blabla/agora/dao/VoiceRoomRepository.java
+++ b/src/main/java/com/gsm/blabla/agora/dao/VoiceRoomRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface VoiceRoomRepository extends JpaRepository<VoiceRoom, Long> {
 
     Boolean existsByMemberId(Long memberId);
+    List<VoiceRoom> findAllByInVoiceRoom(Boolean inVoiceRoom);
     VoiceRoom findByMemberId(Long memberId);
 }

--- a/src/main/java/com/gsm/blabla/agora/dao/VoiceRoomRepository.java
+++ b/src/main/java/com/gsm/blabla/agora/dao/VoiceRoomRepository.java
@@ -2,11 +2,12 @@ package com.gsm.blabla.agora.dao;
 
 import com.gsm.blabla.agora.domain.VoiceRoom;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoiceRoomRepository extends JpaRepository<VoiceRoom, Long> {
 
     Boolean existsByMemberId(Long memberId);
     List<VoiceRoom> findAllByInVoiceRoom(Boolean inVoiceRoom);
-    VoiceRoom findByMemberId(Long memberId);
+    Optional<VoiceRoom> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/gsm/blabla/agora/dao/VoiceRoomRepository.java
+++ b/src/main/java/com/gsm/blabla/agora/dao/VoiceRoomRepository.java
@@ -1,0 +1,11 @@
+package com.gsm.blabla.agora.dao;
+
+import com.gsm.blabla.agora.domain.VoiceRoom;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoiceRoomRepository extends JpaRepository<VoiceRoom, Long> {
+
+    Boolean existsByMemberId(Long memberId);
+    VoiceRoom findByMemberId(Long memberId);
+}

--- a/src/main/java/com/gsm/blabla/agora/domain/VoiceRoom.java
+++ b/src/main/java/com/gsm/blabla/agora/domain/VoiceRoom.java
@@ -1,0 +1,37 @@
+package com.gsm.blabla.agora.domain;
+
+import com.gsm.blabla.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class VoiceRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    private Boolean inVoiceRoom;
+
+    @Builder
+    public VoiceRoom(Member member, Boolean inVoiceRoom) {
+        this.member = member;
+        this.inVoiceRoom = inVoiceRoom;
+    }
+
+    public void updateInVoiceRoom(Boolean inVoiceRoom) {
+        this.inVoiceRoom = inVoiceRoom;
+    }
+}

--- a/src/main/java/com/gsm/blabla/crew/api/CrewController.java
+++ b/src/main/java/com/gsm/blabla/crew/api/CrewController.java
@@ -7,8 +7,6 @@ import com.gsm.blabla.member.dto.MemberProfileResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import java.io.IOException;
-import java.time.LocalTime;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gsm.blabla.admin.application.FcmService;
 import com.gsm.blabla.admin.dto.FcmMessageRequestDto;
+import com.gsm.blabla.agora.dao.VoiceRoomRepository;
+import com.gsm.blabla.agora.domain.VoiceRoom;
 import com.gsm.blabla.crew.dao.*;
 import com.gsm.blabla.crew.domain.*;
 import com.gsm.blabla.crew.dto.*;
@@ -46,6 +48,7 @@ public class CrewService {
     private final RestTemplate restTemplate;
     private final CrewReportAnalysisRepository crewReportAnalysisRepository;
     private final CrewReportKeywordRepository crewReportKeywordRepository;
+    private final VoiceRoomRepository voiceRoomRepository;
 
     @Value("${ai.voice-analysis-request-url}")
     private String voiceAnalysisRequestUrl;
@@ -93,6 +96,14 @@ public class CrewService {
         }
 
         Long memberId = SecurityUtil.getMemberId();
+
+        boolean inVoiceRoom = voiceRoomRepository.existsByMemberId(memberId);
+        if (inVoiceRoom) {
+            VoiceRoom voiceRoom = voiceRoomRepository.findByMemberId(memberId);
+            voiceRoom.updateInVoiceRoom(false);
+        } else {
+            throw new GeneralException(Code.MEMBER_NOT_IN_VOICE_ROOM, "보이스룸에 접속하지 않은 유저입니다.");
+        }
 
         String fileName = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm"));
         String filePath = String.format("reports/%s/members/%s/%s/%s.wav", String.valueOf(reportId), String.valueOf(memberId), fileName, fileName);

--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -99,7 +99,9 @@ public class CrewService {
 
         boolean inVoiceRoom = voiceRoomRepository.existsByMemberId(memberId);
         if (inVoiceRoom) {
-            VoiceRoom voiceRoom = voiceRoomRepository.findByMemberId(memberId);
+            VoiceRoom voiceRoom = voiceRoomRepository.findByMemberId(memberId).orElseThrow(
+                    () -> new GeneralException(Code.MEMBER_NOT_IN_VOICE_ROOM, "보이스룸에 접속하지 않은 유저입니다.")
+            );
             voiceRoom.updateInVoiceRoom(false);
         } else {
             throw new GeneralException(Code.MEMBER_NOT_IN_VOICE_ROOM, "보이스룸에 접속하지 않은 유저입니다.");

--- a/src/main/java/com/gsm/blabla/global/config/SecurityConfig.java
+++ b/src/main/java/com/gsm/blabla/global/config/SecurityConfig.java
@@ -64,12 +64,10 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorizeRequests ->
                 authorizeRequests
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                    .requestMatchers("/**").permitAll()
                     .requestMatchers(
                         "/oauth/**",
-                        "/ko/common/levels/**","/ko/common/keywords/**",
-                        "/en/common/levels/**","/en/common/keywords/**",
-                        "/members/nicknames/**"
+                        "/members/nicknames/**",
+                        "/admin/**"
                     ).permitAll()
                     .requestMatchers(PathRequest.toH2Console()).permitAll() // H2-console 화면을 사용하기 위해
                     .anyRequest().authenticated()

--- a/src/main/java/com/gsm/blabla/global/response/Code.java
+++ b/src/main/java/com/gsm/blabla/global/response/Code.java
@@ -90,6 +90,13 @@ public enum Code {
     FCM_FAILED("FCM001", HttpStatus.INTERNAL_SERVER_ERROR, "FCM failed"),
 
     /*
+     * VoiceRoom 관련 오류
+     * HEAD NAME - VR (VoiceRoom)
+     * */
+    ALREADY_IN_VOICE_ROOM("VR001", HttpStatus.BAD_REQUEST, "Already in voice room"),
+    MEMBER_NOT_IN_VOICE_ROOM("VR002", HttpStatus.BAD_REQUEST, "Member not in voice room"),
+
+    /*
     * 서버 관련 오류
     * HEAD NAME - S (Server)
     * */

--- a/src/main/java/com/gsm/blabla/global/response/Code.java
+++ b/src/main/java/com/gsm/blabla/global/response/Code.java
@@ -66,7 +66,7 @@ public enum Code {
 
     /*
      * Content Detail 관련 오류
-     * HEAD NAME - CTD (Content Detail)
+     * HEAD NAME - CTD (ContentDetail)
      * */
     CONTENT_DETAIL_NOT_FOUND("CTD001", HttpStatus.NOT_FOUND, "Content Detail not found"),
 
@@ -84,7 +84,7 @@ public enum Code {
     PRACTICE_HISTORY_FILE_SIZE_EXCEEDED("PH001", HttpStatus.BAD_REQUEST, "PracticeHistory file size exceeded"),
 
     /*
-     * fcm 관련 오류
+     * FCM 관련 오류
      * HEAD NAME - fcm (fcm)
      * */
     FCM_FAILED("FCM001", HttpStatus.INTERNAL_SERVER_ERROR, "FCM failed"),

--- a/src/main/java/com/gsm/blabla/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/gsm/blabla/member/dto/MemberResponseDto.java
@@ -37,4 +37,12 @@ public class MemberResponseDto {
             .comment(voiceFile.getFeedback())
             .build();
     }
+
+    public static MemberResponseDto voiceRoomResponse(Member member) {
+        return MemberResponseDto.builder()
+            .id(member.getId())
+            .nickname(member.getNickname())
+            .profileImage(member.getProfileImage())
+            .build();
+    }
 }

--- a/src/test/java/com/gsm/blabla/agora/api/AgoraControllerTest.java
+++ b/src/test/java/com/gsm/blabla/agora/api/AgoraControllerTest.java
@@ -1,8 +1,10 @@
 package com.gsm.blabla.agora.api;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -12,7 +14,11 @@ import com.gsm.blabla.agora.dto.RtcTokenDto;
 import com.gsm.blabla.agora.dto.VoiceRoomRequestDto;
 import com.gsm.blabla.global.ControllerTestSupport;
 import com.gsm.blabla.global.WithCustomMockUser;
+import com.gsm.blabla.member.domain.Member;
+import com.gsm.blabla.member.dto.MemberResponseDto;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -49,6 +55,32 @@ class AgoraControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.data.token").value("test"))
             .andExpect(jsonPath("$.data.expiresIn").isNumber())
             ;
+    }
 
+    @DisplayName("[GET] 보이스룸에 접속한 유저 목록을 조회한다.")
+    @Test
+    @WithCustomMockUser
+    void getMembers() throws Exception {
+        // given
+        given(agoraService.getMembers())
+            .willReturn(Map.of("members",
+                List.of(
+                    MemberResponseDto.builder().profileImage("dog").nickname("test1").build(),
+                    MemberResponseDto.builder().profileImage("lion").nickname("test2").build(),
+                    MemberResponseDto.builder().profileImage("wolf").nickname("test3").build()
+                )
+                ));
+
+        // when // then
+        mockMvc.perform(
+            get("/crews/voice-room")
+
+        )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.members", hasSize(3)))
+            .andExpect(jsonPath("$.data.members[0].nickname").value("test1"))
+            .andExpect(jsonPath("$.data.members[1].nickname").value("test2"))
+            .andExpect(jsonPath("$.data.members[2].nickname").value("test3"));
     }
 }

--- a/src/test/java/com/gsm/blabla/agora/api/AgoraControllerTest.java
+++ b/src/test/java/com/gsm/blabla/agora/api/AgoraControllerTest.java
@@ -14,7 +14,6 @@ import com.gsm.blabla.agora.dto.RtcTokenDto;
 import com.gsm.blabla.agora.dto.VoiceRoomRequestDto;
 import com.gsm.blabla.global.ControllerTestSupport;
 import com.gsm.blabla.global.WithCustomMockUser;
-import com.gsm.blabla.member.domain.Member;
 import com.gsm.blabla.member.dto.MemberResponseDto;
 import java.util.Date;
 import java.util.List;

--- a/src/test/java/com/gsm/blabla/agora/application/AgoraServiceTest.java
+++ b/src/test/java/com/gsm/blabla/agora/application/AgoraServiceTest.java
@@ -9,6 +9,9 @@ import com.gsm.blabla.crew.dao.CrewReportRepository;
 import com.gsm.blabla.global.IntegrationTestSupport;
 import com.gsm.blabla.global.WithCustomMockUser;
 import com.gsm.blabla.member.domain.Member;
+import com.gsm.blabla.member.dto.MemberResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,16 +21,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class AgoraServiceTest extends IntegrationTestSupport {
     Member member1;
-
-    @Autowired
-    private AgoraService agoraService;
-
-    @Autowired
-    private CrewReportRepository crewReportRepository;
+    Member member2;
+    LocalDateTime now = LocalDateTime.now();
 
     @BeforeEach
     void setUp() {
-        member1 = createMember("테스트", "cat");
+        member1 = createMember("테스트1", "cat");
+        member2 = createMember("테스트2", "dog");
     }
 
     @DisplayName("[POST] 보이스룸 입장을 위한 토큰을 발급 받는다.")
@@ -51,20 +51,21 @@ class AgoraServiceTest extends IntegrationTestSupport {
     @DisplayName("[POST] 보이스룸 최초 입장 시, 크루 리포트 엔티티가 저장된다.")
     @Test
     @WithCustomMockUser
-    void createFirst() {
+    void crewReportCreatedAtFirst() {
         // given
         VoiceRoomRequestDto voiceRoomRequestDto = VoiceRoomRequestDto.builder()
             .isActivated(false)
             .build();
-        Long beforeTokenCreated = crewReportRepository.count();
+        long beforeTokenCreated = crewReportRepository.count();
 
         // when
-        RtcTokenDto rtcTokenDto = agoraService.create(voiceRoomRequestDto);
-        Long afterTokenCreated = crewReportRepository.count();
+        agoraService.create(voiceRoomRequestDto);
+        long afterTokenCreated = crewReportRepository.count();
 
         // then
         assertThat(afterTokenCreated).isEqualTo(beforeTokenCreated + 1);
     }
+
     @DisplayName("[POST] 보이스룸 최초 입장 시, 보이스룸 엔티티가 저장된다.")
     @Test
     @WithCustomMockUser
@@ -81,5 +82,26 @@ class AgoraServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(afterTokenCreated).isEqualTo(beforeTokenCreated + 1);
+    }
+
+    @DisplayName("[GET] 보이스룸에 접속한 유저 목록을 조회한다.")
+    @Test
+    @WithCustomMockUser
+    void getMembers() {
+        // given
+        startVoiceRoom(now, member1);
+        joinVoiceRoom(member2);
+
+        // when
+        List<MemberResponseDto> response = agoraService.getMembers().get("members");
+
+        // then
+        assertThat(response).hasSize(2);
+        assertThat(response)
+            .extracting("id", "nickname", "profileImage")
+            .containsExactlyInAnyOrder(
+                tuple(member1.getId(), member1.getNickname(), member1.getProfileImage()),
+                tuple(member2.getId(), member2.getNickname(), member2.getProfileImage())
+            );
     }
 }

--- a/src/test/java/com/gsm/blabla/agora/application/AgoraServiceTest.java
+++ b/src/test/java/com/gsm/blabla/agora/application/AgoraServiceTest.java
@@ -2,10 +2,8 @@ package com.gsm.blabla.agora.application;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.gsm.blabla.agora.dao.VoiceRoomRepository;
 import com.gsm.blabla.agora.dto.RtcTokenDto;
 import com.gsm.blabla.agora.dto.VoiceRoomRequestDto;
-import com.gsm.blabla.crew.dao.CrewReportRepository;
 import com.gsm.blabla.global.IntegrationTestSupport;
 import com.gsm.blabla.global.WithCustomMockUser;
 import com.gsm.blabla.member.domain.Member;
@@ -17,7 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.springframework.beans.factory.annotation.Autowired;
 
 class AgoraServiceTest extends IntegrationTestSupport {
     Member member1;

--- a/src/test/java/com/gsm/blabla/agora/application/AgoraServiceTest.java
+++ b/src/test/java/com/gsm/blabla/agora/application/AgoraServiceTest.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class AgoraServiceTest extends IntegrationTestSupport {
     Member member1;
-    Long crewId;
 
     @Autowired
     private AgoraService agoraService;

--- a/src/test/java/com/gsm/blabla/agora/application/AgoraServiceTest.java
+++ b/src/test/java/com/gsm/blabla/agora/application/AgoraServiceTest.java
@@ -2,6 +2,7 @@ package com.gsm.blabla.agora.application;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.gsm.blabla.agora.dao.VoiceRoomRepository;
 import com.gsm.blabla.agora.dto.RtcTokenDto;
 import com.gsm.blabla.agora.dto.VoiceRoomRequestDto;
 import com.gsm.blabla.crew.dao.CrewReportRepository;
@@ -61,6 +62,23 @@ class AgoraServiceTest extends IntegrationTestSupport {
         // when
         RtcTokenDto rtcTokenDto = agoraService.create(voiceRoomRequestDto);
         Long afterTokenCreated = crewReportRepository.count();
+
+        // then
+        assertThat(afterTokenCreated).isEqualTo(beforeTokenCreated + 1);
+    }
+    @DisplayName("[POST] 보이스룸 최초 입장 시, 보이스룸 엔티티가 저장된다.")
+    @Test
+    @WithCustomMockUser
+    void voiceRoomcreatedAtFirst() {
+        // given
+        VoiceRoomRequestDto voiceRoomRequestDto = VoiceRoomRequestDto.builder()
+            .isActivated(false)
+            .build();
+        long beforeTokenCreated = voiceRoomRepository.count();
+
+        // when
+        agoraService.create(voiceRoomRequestDto);
+        long afterTokenCreated = voiceRoomRepository.count();
 
         // then
         assertThat(afterTokenCreated).isEqualTo(beforeTokenCreated + 1);

--- a/src/test/java/com/gsm/blabla/content/dao/ContentDetailRepositoryTest.java
+++ b/src/test/java/com/gsm/blabla/content/dao/ContentDetailRepositoryTest.java
@@ -3,11 +3,8 @@ package com.gsm.blabla.content.dao;
 import com.gsm.blabla.content.domain.Content;
 import com.gsm.blabla.content.domain.ContentDetail;
 import com.gsm.blabla.global.RepositoryTestSupport;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalTime;
 import java.util.List;

--- a/src/test/java/com/gsm/blabla/content/dao/ContentRepositoryTest.java
+++ b/src/test/java/com/gsm/blabla/content/dao/ContentRepositoryTest.java
@@ -2,7 +2,6 @@ package com.gsm.blabla.content.dao;
 
 import com.gsm.blabla.content.domain.Content;
 import com.gsm.blabla.global.RepositoryTestSupport;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/gsm/blabla/crew/api/ScheduleControllerTest.java
+++ b/src/test/java/com/gsm/blabla/crew/api/ScheduleControllerTest.java
@@ -67,7 +67,6 @@ class ScheduleControllerTest extends ControllerTestSupport {
         // when // then
         mockMvc.perform(
             get("/crews/schedules")
-                .header("Authorization", "test")
         )
             .andDo(print())
             .andExpect(status().isOk())

--- a/src/test/java/com/gsm/blabla/crew/dao/ScheduleRepositoryTest.java
+++ b/src/test/java/com/gsm/blabla/crew/dao/ScheduleRepositoryTest.java
@@ -9,8 +9,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 class ScheduleRepositoryTest extends RepositoryTestSupport {
 

--- a/src/test/java/com/gsm/blabla/global/IntegrationTestSupport.java
+++ b/src/test/java/com/gsm/blabla/global/IntegrationTestSupport.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.security.core.parameters.P;
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
#229 

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
- SecurityConfig permitAll 대상을 변경했습니다.
- 보이스룸 입장 API, 분석 요청 API에 보이스룸 접속 여부를 저장/변경하는 로직을 추가했습니다.
- 보이스룸 접속 유저 목록 조회 API를 구현했습니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->
- 셀프 리뷰로 작성하겠습니다.
- 현재는 DB에 저장하지만, 추후 Redis로 변경하여 관리할 예정입니다.

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
<img width="515" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/0bd1b845-b245-4c1a-a105-51f59b42e647">

## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
