### PR TITLE
fix: webSecurityCustomizer에서 H2 관련 코드 제거

### DIFF
--- a/src/main/java/com/gsm/blabla/global/config/SecurityConfig.java
+++ b/src/main/java/com/gsm/blabla/global/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
-            .requestMatchers("/h2-console/**", "/swagger-ui/**");
+            .requestMatchers( "/swagger-ui/**");
     }
 
     @Bean


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
X

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
- 서버 에러를 고치기 위해 SecurityConfig의 webSecurityCustomizer 메서드에서 H2 관련 코드를 제거하였습니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
<img width="456" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/16836cbd-e465-4ab8-b2c3-d7965ccb10bc">

## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
