### PR TITLE
fix: createVoiceFile API에서 member값 받아오는 로직 수정

### DIFF
--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -66,13 +66,17 @@ public class CrewService {
             throw new GeneralException(Code.VOICE_ANALYSIS_IS_NULL, "음성 분석 결과가 비어있습니다.");
         }
 
+        Member member = memberRepository.findById(voiceAnalysisResponseDto.getMemberId()).orElseThrow(
+                () -> new GeneralException(Code.MEMBER_NOT_FOUND, "존재하지 않는 유저입니다.")
+        );
+
         CrewReport crewReport = crewReportRepository.findById(reportId).orElseThrow(
                 () -> new GeneralException(Code.REPORT_NOT_FOUND, "존재하지 않는 리포트입니다.")
         );
 
         voiceFileRepository.save(
                 VoiceFile.builder()
-                        .member(crewReport.getMember())
+                        .member(member)
                         .crewReport(crewReport)
                         .fileUrl(voiceAnalysisResponseDto.getFileUrl())
                         .totalCallTime(voiceAnalysisResponseDto.getTotalCallTime())
@@ -108,6 +112,7 @@ public class CrewService {
         Map<String, String> paramMap = new HashMap<>();
         paramMap.put("fileUrl", fileUrl);
         paramMap.put("reportId", String.valueOf(reportId));
+        paramMap.put("memberId", String.valueOf(memberId));
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/gsm/blabla/crew/application/CrewService.java
+++ b/src/main/java/com/gsm/blabla/crew/application/CrewService.java
@@ -66,19 +66,13 @@ public class CrewService {
             throw new GeneralException(Code.VOICE_ANALYSIS_IS_NULL, "음성 분석 결과가 비어있습니다.");
         }
 
-        Long memberId = SecurityUtil.getMemberId();
-
         CrewReport crewReport = crewReportRepository.findById(reportId).orElseThrow(
                 () -> new GeneralException(Code.REPORT_NOT_FOUND, "존재하지 않는 리포트입니다.")
         );
 
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new GeneralException(Code.MEMBER_NOT_FOUND, "존재하지 않는 유저입니다.")
-        );
-
         voiceFileRepository.save(
                 VoiceFile.builder()
-                        .member(member)
+                        .member(crewReport.getMember())
                         .crewReport(crewReport)
                         .fileUrl(voiceAnalysisResponseDto.getFileUrl())
                         .totalCallTime(voiceAnalysisResponseDto.getTotalCallTime())

--- a/src/main/java/com/gsm/blabla/crew/dto/VoiceAnalysisResponseDto.java
+++ b/src/main/java/com/gsm/blabla/crew/dto/VoiceAnalysisResponseDto.java
@@ -18,6 +18,7 @@ import java.time.format.DateTimeFormatter;
 @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
 public class VoiceAnalysisResponseDto {
 
+    private Long memberId;
     private String fileUrl;
 
     @JsonDeserialize(using = LocalTimeDeserializer.class)


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
#233 

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
- 문제: Lambda와 통신하는 음성 파일 분석 API에서는 JWT토큰에서 멤버 아이디를 불러올 수 없다는 문제가 발생했습니다.
  - 해결: crewReport에서 member를 추출하도록 로직으로 수정했습니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
![image](https://github.com/SWM-GSM/blabla-server/assets/62024470/b593945e-6ad4-4186-96bf-56c04b4f907a)

## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
