### PR TITLE
fix: 연습 기록 음성 파일 저장 API 파라미터 수정

### DIFF
--- a/src/main/java/com/gsm/blabla/content/api/ContentController.java
+++ b/src/main/java/com/gsm/blabla/content/api/ContentController.java
@@ -62,7 +62,7 @@ public class ContentController {
     }
 
     @Operation(summary = "연습 기록 음성 파일 저장 API")
-    @PostMapping("/{contentId}/practice")
+    @PostMapping("/detail/{contentDetailId}/practice")
     public DataResponseDto<Map<String, String>> createPracticeHistory(
             @PathVariable Long contentDetailId,
             @RequestParam("files") List<MultipartFile> files) {


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
#235 

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
- 리팩토링 과정에서 연습 기록 음성 파일 저장 API 파라미터명이 변경되어 동작하지 않는 문제가 발생하여 이를 수정했습니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
- 빠른 수정을 위해 테스트 코드는 추후 작성할 예정입니다. 대신 Postman과 S3 저장 결과 첨부하겠습니다!
<img width="1175" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/62024470/cd839078-0448-4352-8a96-684693dcf2ee">

![image](https://github.com/SWM-GSM/blabla-server/assets/62024470/b8a806b9-e96d-481b-b06a-63ac15db41d9)


## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
