### PR TITLE
fix: 보이스룸 재접속 시 예외 처리를 반환하는 에러 수정

### DIFF
--- a/src/main/java/com/gsm/blabla/agora/application/AgoraService.java
+++ b/src/main/java/com/gsm/blabla/agora/application/AgoraService.java
@@ -60,10 +60,21 @@ public class AgoraService {
              );
         }
 
-        boolean inVoiceRoom = voiceRoomRepository.existsByMemberId(memberId);
-        if (inVoiceRoom) {
-            throw new GeneralException(Code.ALREADY_IN_VOICE_ROOM, "이미 보이스 채팅방에 입장하셨습니다.");
-        } else {
+        boolean inVoiceRoomExist = voiceRoomRepository.existsByMemberId(memberId);
+        if (inVoiceRoomExist) { // 보이스룸 접속 이력이 있는 유저
+            boolean inVoiceRoomIsTrue = voiceRoomRepository.findByMemberId(memberId).orElseThrow(
+                    () -> new GeneralException(Code.MEMBER_NOT_IN_VOICE_ROOM, "보이스룸 접속 이력이 없는 유저입니다.")
+                )
+                .getInVoiceRoom();
+            if (inVoiceRoomIsTrue) {
+                throw new GeneralException(Code.ALREADY_IN_VOICE_ROOM, "이미 보이스룸에 입장하셨습니다.");
+            } else {
+                VoiceRoom voiceRoom = voiceRoomRepository.findByMemberId(memberId).orElseThrow(
+                    () -> new GeneralException(Code.MEMBER_NOT_IN_VOICE_ROOM, "보이스룸에 접속하지 않은 유저입니다.")
+                );
+                voiceRoom.updateInVoiceRoom(true);
+            }
+        } else { // 보이스룸 접속 이력이 없는 유저
             voiceRoomRepository.save(
                 VoiceRoom.builder()
                     .member(memberRepository.findById(memberId).orElseThrow(


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
#229 

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
기존에는 보이스룸 접속 여부를 `existsByMemberId`로만 판단하기 때문에 최초 접속이 아닌 유저들은 inVoiceRoom이 false이지만 보이스룸 접속 중으로 판단되는 문제가 있었습니다.
`existsByMemberId`와 `inVoiceRoom이 true`여야 보이스룸 접속 중으로 판단하도록 로직을 변경하였습니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->
- 빠른 배포를 위해 클린 코드에 집중하지 못했습니다 ㅠㅠ 현재 로직이 중첩 if문으로 구성되었는데 나중에 리팩토링하겠습니다...!!

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
빠른 배포를 위해 작성하지 못했습니다. 추후 작성하겠습니다.
대신 포스트맨 결과 첨부하겠습니다!
기존 테스트 코드들은 정상 동작합니다 :) (아래 스샷 참고)
![image](https://github.com/SWM-GSM/blabla-server/assets/65899774/a2dee738-eb22-4dc1-a6b9-4bbe0bbae978)

### 1. 유저가 보이스룸을 처음 입장한다
<img width="1225" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/f16985d2-e86d-46e1-a50e-304a8fe918c9">
<img width="353" alt="Pasted Graphic" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/914e35e4-3129-442f-870c-24983220353e">

### 2. 유저가 보이스룸을 나간다.
<img width="271" alt="Pasted Graphic 2" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/00b35af1-2f7e-408a-acb3-41e584c348d7">

### 3. 유저가 보이스룸을 재접속한다.
<img width="1223" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/024bd5ce-72cd-415f-a9a1-228b2ab5d442">
<img width="302" alt="Pasted Graphic 3" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/66e79d47-a9f0-4046-86c6-2feb2aa83d2d">


## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
