### PR TITLE
deploy: Github Actions CI/CD 스크립트 분리

### DIFF
--- a/.github/workflows/blabla-cd.yml
+++ b/.github/workflows/blabla-cd.yml
@@ -10,7 +10,7 @@ jobs:
   CD:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACTION_TOKEN }}
           submodules: true

--- a/.github/workflows/blabla-cd.yml
+++ b/.github/workflows/blabla-cd.yml
@@ -1,14 +1,13 @@
-name: API Server - CI/CD
+name: blabla API Server - CD
 
 on:
   push:
-    branches: ["main", "develop"]
-
-permissions:
-  contents: read
+    branches:
+      - main
+      - develop
 
 jobs:
-  CI-CD:
+  CD:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,11 +26,6 @@ jobs:
 
       - name: Run build with Gradle Wrapper
         run: ./gradlew clean build
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Make zip file
         run: zip -qq -r ./$GITHUB_SHA.zip .

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -1,0 +1,36 @@
+name: blabla API Server - CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.ACTION_TOKEN }}
+          submodules: true
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Run build with Gradle Wrapper
+        run: ./gradlew clean build
+
+      - name: Report to CodeCov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./build/reports/jacoco/test/jacoco.xml

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -1,9 +1,10 @@
 name: blabla API Server - CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - develop
+    types: [labeled]
 
 permissions:
   contents: read
@@ -11,6 +12,7 @@ permissions:
 jobs:
   CI:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - develop
     types: [labeled]
+    labels:
+      - 'safe to test'
 
 permissions:
   contents: read

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -12,7 +12,7 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACTION_TOKEN }}
           submodules: true


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
#199 

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
(Labels 테스트를 위해 다시 PR을 보냅니다.)

Github Actions 스크립트에서 CI와 CD를 분리하였습니다.
- CI : develop 브랜치에 PR이 올라올 때 실행됩니다.
- CD : main 브랜치에 PR이 올라올 때 실행됩니다.

#260 의 코멘트에 작성한 것처럼 PR Comment로 분석 결과를 받기 위해서는 trigger 조건 기존처럼 `push`일 때가 아닌 `pull_request`가 되어야 합니다.

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->
X

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
<img width="453" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/c76d464a-4c48-4a68-b219-78db6efcd668">


## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
