### PR TITLE
deploy: Github Actions CI/CD 스크립트 분리

### DIFF
--- a/.github/workflows/blabla-cd.yml
+++ b/.github/workflows/blabla-cd.yml
@@ -10,7 +10,7 @@ jobs:
   CD:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACTION_TOKEN }}
           submodules: true

--- a/.github/workflows/blabla-cd.yml
+++ b/.github/workflows/blabla-cd.yml
@@ -1,14 +1,13 @@
-name: API Server - CI/CD
+name: blabla API Server - CD
 
 on:
   push:
-    branches: ["main", "develop"]
-
-permissions:
-  contents: read
+    branches:
+      - main
+      - develop
 
 jobs:
-  CI-CD:
+  CD:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,11 +26,6 @@ jobs:
 
       - name: Run build with Gradle Wrapper
         run: ./gradlew clean build
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Make zip file
         run: zip -qq -r ./$GITHUB_SHA.zip .

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -1,0 +1,36 @@
+name: blabla API Server - CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.ACTION_TOKEN }}
+          submodules: true
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Run build with Gradle Wrapper
+        run: ./gradlew clean build
+
+      - name: Report to CodeCov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./build/reports/jacoco/test/jacoco.xml

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -1,9 +1,10 @@
 name: blabla API Server - CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - develop
+    types: [labeled]
 
 permissions:
   contents: read
@@ -11,6 +12,7 @@ permissions:
 jobs:
   CI:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - develop
     types: [labeled]
+    labels:
+      - 'safe to test'
 
 permissions:
   contents: read

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -12,7 +12,7 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACTION_TOKEN }}
           submodules: true

--- a/.github/workflows/blabla-ci.yml
+++ b/.github/workflows/blabla-ci.yml
@@ -1,12 +1,9 @@
 name: blabla API Server - CI
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - develop
-    types: [labeled]
-    labels:
-      - 'safe to test'
 
 permissions:
   contents: read
@@ -14,7 +11,6 @@ permissions:
 jobs:
   CI:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
- Issue: #199 
- PR: #261, #263 

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
이전 PR의 comment에서 설명한 것처럼 forked repository에서 PR을 올릴 때 secrets에 접근할 수 없습니다.
대안으로 pull_request_target을 사용하되, 보안 문제가 발생하지 않도록 해보려고 했습니다. 
하지만, 구글링해본 결과 pull_request_target을 사용하며 secrets를 완벽히 보안하는 방법은 없고 많은 아티클들이 제안해주는 방법은 일시적인 방법입니다.

그 결과, actions 스크립트를 수정하기보다는 협업 방식에 변화를 두는 것이 더 효율적이라고 생각했습니다.
하지만 public repository이기 때문에 이 경우에도 외부인이 저희 repo에 접근하여 secrets에 접근할 수 있습니다. 우선 branch protection rule을 통해 push 권한에 제한을 두는 방식으로 해결했습니다. 더 좋은 방식 있으면 추천 부탁드려요 ~!

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->
- 앞으로 Push는 fork repository(origin) 대신 원본 repository(upstream)으로 부탁드립니다.
  - **main, develop 브랜치에 push하지 않도록 주의 !!!** 

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
코드 변경이 없어 테스트 코드 결과를 첨부하지 않았습니다.

## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
