### PR TITLE
fix: Sentry 로그 출력 형식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,9 @@ dependencies {
 
     // flyway
     implementation 'org.flywaydb:flyway-mysql'
+
+    // sentry
+    implementation 'io.sentry:sentry-logback:6.19.0'
 }
 
 tasks.named('test') {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -39,7 +39,7 @@
         <level>ERROR</level>
       </filter>
       <encoder>
-        <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
+        <pattern>${CONSOLE_LOG_PATTERN}</pattern>
       </encoder>
     </appender>
 
@@ -81,7 +81,7 @@
         <level>ERROR</level>
       </filter>
       <encoder>
-        <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
+        <pattern>${CONSOLE_LOG_PATTERN}</pattern>
       </encoder>
     </appender>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -34,9 +34,19 @@
       </filter>
     </appender>
 
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+      </filter>
+      <encoder>
+        <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
+      </encoder>
+    </appender>
+
     <root level="INFO">
       <appender-ref ref="ASYNC_DISCORD"/>
       <appender-ref ref="Console"/>
+      <appender-ref ref="Sentry"/>
     </root>
   </springProfile>
   <springProfile name="prod">
@@ -66,9 +76,19 @@
       </filter>
     </appender>
 
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+      </filter>
+      <encoder>
+        <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
+      </encoder>
+    </appender>
+
     <root level="INFO">
       <appender-ref ref="ASYNC_DISCORD"/>
       <appender-ref ref="Console"/>
+      <appender-ref ref="Sentry"/>
     </root>
   </springProfile>
 </configuration>


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- 이슈 번호가 없을 경우, X라고 기입해주세요. -->
#273

## 🪐 작업 내용
<!-- 주요 변경사항에 대해 설명해주세요 -->
<img width="1306" alt="image" src="https://github.com/SWM-GSM/blabla-server/assets/65899774/94e6f194-7d82-4ddd-8246-c0a872d134af">

Sentry에서 Message 부분에 출력될 문구 형식을 변경했습니다.
(기존에 사용했던 로그 출력 패턴은 디스코드용 패턴입니다.)

## 👋 리뷰어가 중점적으로 확인해야 할 것 (Optional)
<!-- 리뷰어에게 중점적으로 리뷰 받고 싶은 부분을 적어주세요 -->
X

## 🔬 테스트 코드 결과
<!-- 테스트 코드를 작성하지 않았을 경우, 미작성 사유를 적어주세요. -->
코드 변경이 없어 테스트 코드 결과를 첨부하지 않았습니다.

## ✅ Check List
<!-- PR을 올리기 전, 머지를 하기 전 아래 체크리스트를 점검해주세요. -->
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Reviewer를 지정했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
